### PR TITLE
docs: expand zensical site coverage

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -1,0 +1,120 @@
+# Architecture
+
+netbox-wdm is built on three architectural ideas:
+
+1. **Overlay pattern.** WDM data is layered on top of NetBox's existing DCIM
+   models rather than replacing them.
+2. **Position-stack alignment.** Channel `grid_position` is the single integer
+   that flows from `WdmChannelPlan` through `WdmChannel` to
+   `dcim.PortMapping.rear_port_position`.
+3. **Signal-driven rebuilds.** Wavelength paths and port-sync state are
+   recomputed automatically on transaction commit when relevant DCIM or WDM
+   models change.
+
+This page captures the contracts between modules. Later pages describe the
+individual subsystems in depth.
+
+## Overlay pattern
+
+| WDM model | DCIM model | Cardinality |
+|-----------|-----------|-------------|
+| `WdmProfile` | `dcim.DeviceType` | 1:1 |
+| `WdmChannelPlan` | `dcim.FrontPortTemplate` (mux + demux) | many-to-one on profile, 1:1 on each FP template |
+| `WdmNode` | `dcim.Device` | 1:1 |
+| `WdmLinePort` | `dcim.RearPort` | 1:1 |
+| `WdmChannel` | `dcim.FrontPort` (mux + demux) | many-to-one on node, 1:1 on each FP |
+
+Every WDM model is a `netbox.models.NetBoxModel`, so it inherits tagging,
+custom fields, journaling, and the standard NetBox object views.
+
+The overlay is intentional. NetBox's DCIM stack already tracks ports,
+positions, port mappings, cables, and cable paths. The plugin would have to
+re-implement all of that to model WDM as a parallel concept. By overlaying,
+all standard NetBox features (cabling, search, filtering, custom fields,
+tags, audit trail) keep working on the underlying objects, and WDM-specific
+state lives on a thin layer above.
+
+## Position-stack alignment
+
+Real WDM hardware multiplexes per-channel client ports onto a single COM
+rear port (or pair of COM rear ports). NetBox already models this with
+`PortTemplateMapping` (template-level) and `PortMapping` (instance-level):
+each FrontPort can be linked to a RearPort at a specific
+`rear_port_position`.
+
+netbox-wdm uses `grid_position` as the bridge between ITU and NetBox:
+
+- On the template side, `WdmChannelPlan.grid_position` records the channel's
+  index in the ITU grid. The template author also creates one
+  `PortTemplateMapping` per channel mapping `mux_front_port_template` to a
+  COM rear port template at this same position.
+- On the instance side, `WdmChannel.grid_position` is copied from the
+  template (positions never drift across the overlay). Whenever the plugin
+  emits a `PortMapping` (during `apply-mapping` or port sync), it sets
+  `rear_port_position = channel.grid_position`.
+
+This keeps `dcim.CablePath` honest: when a wavelength enters the COM rear
+port it picks the right channel's front port back out, even when many
+channels share the same trunk fibre.
+
+EXP and 1310 pass-through ports use the **same** COM rear ports but at
+positions **after** the channel positions. They are present in the
+DeviceType templates so cable tracing knows about them, but they are not
+part of any `WdmChannel`. The port-sync hash deliberately excludes them.
+
+## Module map
+
+The package layout follows the standard NetBox plugin structure:
+
+| Path | Purpose |
+|------|---------|
+| `netbox_wdm/__init__.py` | `PluginConfig` with version, base URL, and `ready()` hook |
+| `netbox_wdm/models.py` | `WdmProfile`, `WdmChannelPlan`, `WdmNode`, `WdmLinePort`, `WdmChannel`, `WdmWavelengthPath`, `WdmWavelengthPathChannel`, `WdmCircuit` |
+| `netbox_wdm/choices.py` | All `ChoiceSet` enums for grid, node type, line direction/role, fibre type, channel/circuit status |
+| `netbox_wdm/wdm_constants.py` | ITU grid tables and `get_channel_info(grid, position)` |
+| `netbox_wdm/signals.py` | post_save / post_delete handlers that trigger path rebuilds and port-sync rechecks |
+| `netbox_wdm/trace.py` | Wavelength path discovery (`trace_wavelength_path`, `rebuild_wavelength_paths_for_node`) |
+| `netbox_wdm/port_sync.py` | Drift detection (`compute_*_port_hash`, `compute_sync_diff`, `apply_sync`) |
+| `netbox_wdm/views.py` | All NetBox `generic.ObjectView` subclasses, including `WdmNodeWavelengthEditorView` and the trace tab views |
+| `netbox_wdm/api/` | DRF serializers, viewsets, router; custom `apply-mapping`, `sync-ports`, `trace`, `stitch` actions |
+| `netbox_wdm/graphql/` | strawberry-django types, filters, and schema |
+| `netbox_wdm/template_content.py` | `PluginTemplateExtension` for Device and Cable detail pages |
+| `netbox_wdm/navigation.py` | The `WDM` plugin menu |
+| `netbox_wdm/template_content.py` | Adds the Device WDM panel and the Cable WDM circuits panel |
+| `netbox_wdm/management/commands/` | `create_wdm_sample_data`, `wdm_sync_ports`, `wdm_rehash_ports` |
+| `netbox_wdm/testing/` | Topology builders shared between sample data and tests |
+| `netbox_wdm/static/netbox_wdm/src/` | TypeScript sources for the wavelength editor and circuit trace renderer |
+
+## Map-layer integration
+
+If the optional `netbox-pathways` plugin is present, `_register_map_layers()`
+in `__init__.py` registers a `wdm_nodes` layer that surfaces every device
+with an attached `WdmNode` on the pathways map. The registration is wrapped
+in a `try/except ImportError` so it is a soft dependency.
+
+## Plugin API imports
+
+The plugin uses NetBox's public plugin API consistently:
+
+| Thing | Import |
+|-------|--------|
+| `NetBoxModel` | `netbox.models.NetBoxModel` |
+| `ChoiceSet` | `utilities.choices.ChoiceSet` |
+| `NetBoxModelForm` | `netbox.forms.NetBoxModelForm` |
+| `NetBoxModelFilterSet` | `netbox.filtersets.NetBoxModelFilterSet` |
+| `NetBoxTable` | `netbox.tables.NetBoxTable` |
+| Generic views | `netbox.views.generic` |
+| `NetBoxModelSerializer` | `netbox.api.serializers.NetBoxModelSerializer` |
+| `NetBoxModelViewSet` | `netbox.api.viewsets.NetBoxModelViewSet` |
+| `NetBoxRouter` | `netbox.api.routers.NetBoxRouter` |
+| `ViewTab`, `register_model_view` | `utilities.views` |
+| `PluginTemplateExtension` | `netbox.plugins.PluginTemplateExtension` |
+
+These imports follow NetBox 4.5's stable plugin contract.
+
+## URL naming convention
+
+All URL names follow `plugins:netbox_wdm:<modelname_lowercase>` for detail
+views, with `_list`, `_add`, `_edit`, `_delete` suffixes. The base URL of
+the plugin is `wdm/` (set in `PluginConfig.base_url`); the REST API lives
+under `/api/plugins/wdm/`.

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -1,0 +1,196 @@
+# Models Reference
+
+This page lists every concrete model defined in `netbox_wdm/models.py`, with
+its fields, key constraints, and any custom save behaviour. All models
+inherit from `netbox.models.NetBoxModel` unless noted otherwise.
+
+## WdmProfile
+
+One-to-one overlay on `dcim.DeviceType`. Holds optical metadata that
+NetBox's DeviceType does not model natively.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `device_type` | `OneToOneField(dcim.DeviceType)` | `related_name="wdm_profile"` |
+| `node_type` | `CharField` | `WdmNodeTypeChoices` |
+| `grid` | `CharField` | `WdmGridChoices` |
+| `fiber_type` | `CharField` | `WdmFiberTypeChoices`; default `duplex` |
+| `description` | `TextField` | Free text |
+
+Clone fields: `node_type`, `grid`, `fiber_type`.
+
+## WdmChannelPlan
+
+Channel template row on a profile. Many-to-one to `WdmProfile`, one-to-one
+to two `dcim.FrontPortTemplate` foreign keys (mux + demux).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `profile` | `ForeignKey(WdmProfile)` | `related_name="channel_plans"`, CASCADE |
+| `grid_position` | `PositiveIntegerField` | 1-based ITU grid position |
+| `wavelength_nm` | `DecimalField(8,2)` | Wavelength in nm |
+| `label` | `CharField(20)` | Display label |
+| `mux_front_port_template` | `ForeignKey(dcim.FrontPortTemplate, SET_NULL)` | TX side |
+| `demux_front_port_template` | `ForeignKey(dcim.FrontPortTemplate, SET_NULL)` | RX side, null for SF |
+
+Constraints (database-enforced, all scoped to a single profile):
+
+- `unique_profile_wavelength`: a wavelength_nm appears once per profile.
+- `unique_profile_grid_position`: a grid_position appears once per profile.
+- `unique_profile_fpt` and `unique_profile_demux_fpt`: a given FrontPortTemplate
+  cannot be referenced by two channel plans on the same profile.
+
+## WdmNode
+
+One-to-one overlay on `dcim.Device`. Owns the device's WDM channels and
+line ports.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `device` | `OneToOneField(dcim.Device)` | `related_name="wdm_node"`, CASCADE |
+| `node_type` | `CharField` | Same choices as profile |
+| `grid` | `CharField` | Same choices as profile |
+| `description` | `TextField` | Free text |
+| `expected_port_hash` | `CharField(64)` | SHA-256 hex digest of expected PortMapping state |
+| `port_sync_valid` | `BooleanField` | Drift flag (default True) |
+
+Clone fields: `node_type`, `grid`.
+
+Properties:
+
+- `is_fixed`: True when `node_type != roadm`. Used to gate edits on
+  `WdmChannel` and `WdmLinePort`.
+
+Methods:
+
+- `validate_channel_mapping(desired_mapping)` enforces protected-channel
+  guards and port-uniqueness when the wavelength editor or `apply-mapping`
+  endpoint runs.
+- `_auto_populate_channels()` runs once on creation. It consumes the
+  device's `device_type.wdm_profile.channel_plans` and bulk-creates one
+  `WdmChannel` per plan, looking up `FrontPort` instances by name.
+- `save()` wraps the parent save in `transaction.atomic` and triggers
+  auto-population on creation when the node type is not `amplifier`.
+
+## WdmLinePort
+
+Identifies a `dcim.RearPort` as a trunk port on a WDM node, and labels its
+direction and role.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `wdm_node` | `ForeignKey(WdmNode)` | `related_name="line_ports"`, CASCADE |
+| `rear_port` | `ForeignKey(dcim.RearPort)` | PROTECT |
+| `direction` | `CharField` | `WdmLineDirectionChoices` (common / east / west) |
+| `role` | `CharField` | `WdmLineRoleChoices` (tx / rx / bidi); default `bidi` |
+
+Constraints:
+
+- `unique_lineport_rear_port`: a rear port can be a line port on at most
+  one WDM node.
+- `unique_lineport_direction_role`: a node has at most one line port per
+  (direction, role) pair.
+
+`save()` and `clean()` call `_check_fixed_fields()`. On nodes where
+`is_fixed=True` the `rear_port`, `direction`, and `role` are immutable
+after creation.
+
+## WdmChannel
+
+One-per-channel record on a node. Carries the live channel-to-port
+mapping and status.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `wdm_node` | `ForeignKey(WdmNode)` | `related_name="channels"`, CASCADE |
+| `grid_position` | `PositiveIntegerField` | Indexed into the node's grid |
+| `mux_front_port` | `ForeignKey(dcim.FrontPort, SET_NULL)` | TX-side client port |
+| `demux_front_port` | `ForeignKey(dcim.FrontPort, SET_NULL)` | RX-side client port |
+| `status` | `CharField` | `WdmChannelStatusChoices`; default `available` |
+
+Constraints:
+
+- `unique_channel_grid_position`: at most one channel per (node,
+  grid_position).
+- `unique_node_mux_fp` and `unique_node_demux_fp`: a FrontPort can only be
+  used by one channel on a given node (each conditional on the FK being
+  non-null).
+
+Properties (computed from the node's grid via `wdm_constants`):
+
+- `label`: ITU label, e.g. `C32`, `CWDM-1310`.
+- `wavelength_nm`: Decimal nm.
+
+Fixed-node guard: only `status` is mutable when `wdm_node.is_fixed=True`.
+
+## WdmWavelengthPath
+
+Auto-discovered end-to-end path for a single wavelength.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `grid_position` | `PositiveIntegerField` | Common to every channel on the path |
+| `wavelength_nm` | `DecimalField(8,2)` | Wavelength in nm |
+| `is_complete` | `BooleanField` | Both endpoints have a client port assigned |
+| `is_active` | `BooleanField` | Every cable status is `connected` and length >= 2 |
+| `is_valid` | `BooleanField` | False on TX-to-TX miscable detection |
+
+Methods:
+
+- `get_channels()` returns the path's channels in sequence order.
+- `get_stitched_path()` returns the path as a list of `PathElement`
+  dataclasses.
+- `get_display_label()` formats as `<wavelength>nm: <node1> -> <node2> ...`.
+
+## WdmWavelengthPathChannel
+
+Through table linking `WdmWavelengthPath` to `WdmChannel` in sequence
+order. Not a `NetBoxModel`; this is a plain `models.Model`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `path` | `ForeignKey(WdmWavelengthPath)` | CASCADE, `related_name="path_channels"` |
+| `channel` | `ForeignKey(WdmChannel)` | PROTECT, `related_name="wavelength_path_entries"` |
+| `sequence` | `PositiveIntegerField` | 0-based hop index |
+
+Constraints:
+
+- `unique_wavelength_path_channel`: a channel appears at most once per path.
+- `unique_wavelength_path_sequence`: each (path, sequence) pair is unique.
+
+## WdmCircuit
+
+Logical service grouping over wavelength paths.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | `CharField(200)` | Required |
+| `status` | `CharField` | `WdmCircuitStatusChoices`; default `planned` |
+| `wavelength_paths` | `ManyToManyField(WdmWavelengthPath)` | M2M, `related_name="circuits"` |
+| `tenant` | `ForeignKey(tenancy.Tenant, SET_NULL)` | Optional |
+| `description` | `TextField` | Free text |
+| `comments` | `TextField` | Free text |
+
+Clone fields: `status`, `tenant`.
+
+`save()` watches for status transitions:
+
+- On move to `decommissioned`, every channel on every attached wavelength
+  path is reset to status `available` and the M2M is cleared.
+
+Methods:
+
+- `get_stitched_paths()` returns `[(path, [PathElement, ...]), ...]`,
+  reusing each path's `get_stitched_path()` helper.
+
+## Choice sets
+
+Defined in `netbox_wdm/choices.py`:
+
+- `WdmNodeTypeChoices`: `terminal_mux`, `oadm`, `roadm`, `amplifier`.
+- `WdmGridChoices`: `dwdm_100ghz`, `dwdm_50ghz`, `cwdm`.
+- `WdmLineDirectionChoices`: `common`, `east`, `west`.
+- `WdmFiberTypeChoices`: `duplex`, `single_fiber`.
+- `WdmLineRoleChoices`: `tx`, `rx`, `bidi`.
+- `WdmChannelStatusChoices`: `available`, `reserved`, `active`.
+- `WdmCircuitStatusChoices`: `planned`, `staged`, `active`, `decommissioned`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,74 @@
 # NetBox WDM
 
-Wavelength Division Multiplexing (WDM) device management for NetBox: ITU channel plans, channel-to-port assignments, ROADM live editing, wavelength service tracking, and interactive circuit trace visualization.
+Wavelength Division Multiplexing (WDM) device management for NetBox.
 
-## Overlay pattern
+netbox-wdm overlays NetBox's `dcim.DeviceType` and `dcim.Device` models with WDM
+specific records: ITU channel plans, channel-to-port assignments, trunk
+direction labelling, ROADM live editing, wavelength service tracking, and
+interactive circuit trace visualisation.
 
-netbox-wdm follows NetBox's Device/DeviceType pattern with overlay models:
+## What it manages
 
-- **WdmDeviceTypeProfile** → 1:1 on `dcim.DeviceType` (the blueprint).
-- **WdmNode** → 1:1 on `dcim.Device` (the instance).
-- **WdmChannelTemplate** → channel-to-port blueprint on a profile.
-- **WdmChannel** → one per ITU channel, links MUX/DEMUX front ports.
-- **WdmWavelengthPath** → end-to-end traced path between WDM nodes.
-- **WdmCircuit** → logical service grouping one or more wavelength paths.
+- **Device-type blueprints** for terminal MUX, OADM, ROADM, and amplifier
+  hardware on the DWDM 100 GHz, DWDM 50 GHz, and CWDM grids.
+- **Channel-to-port assignments** for both duplex (separate MUX/DEMUX fibres)
+  and single-fibre topologies.
+- **Trunk port identification** with direction (common / east / west) and role
+  (TX / RX / bidirectional).
+- **ROADM live editing** with optimistic concurrency and a TypeScript editor.
+- **End-to-end wavelength paths** auto-discovered through the cable plant,
+  including patch panel pass-through and ROADM cross-connects.
+- **Wavelength services (circuits)** that group one or more wavelength paths,
+  with PROTECT guards on assigned channels.
+- **Drift detection (port sync)** when port mappings are edited outside the
+  plugin.
+
+## When to use it
+
+This plugin is for operators of optical transport networks who want NetBox to
+hold the source of truth for:
+
+- Which channels exist on each MUX or ROADM.
+- Which client port maps to which channel on which trunk side.
+- Which wavelengths are lit, reserved, or available across a path.
+- Which physical cables and intermediate patch panels each wavelength
+  traverses.
+
+It is **not** a network management or telemetry tool: it does not poll the
+optical hardware, it tracks documented intent.
 
 ## Quick links
 
-- [User: Port Sync](user/port-sync.md)
-- [Developer: Architecture & Port Sync](developer/port-sync.md)
-- [Developer: Style Guide](developer/style-guide.md)
+User Guide:
+
+- [Getting Started](user/getting-started.md)
+- [WDM Profiles](user/wdm-profiles.md)
+- [WDM Nodes](user/wdm-nodes.md)
+- [ITU Channel Plans](user/itu-grids.md)
+- [Wavelength Editor (ROADM)](user/wavelength-editor.md)
+- [Wavelength Paths and Circuits](user/circuits.md)
+- [Circuit Trace Visualisation](user/circuit-trace.md)
+- [Port Sync](user/port-sync.md)
+
+Developer:
+
+- [Architecture](developer/architecture.md)
+- [Models Reference](developer/models.md)
+- [Port Topology](developer/port-topology.md)
+- [Wavelength Path Tracing](developer/path-tracing.md)
+- [REST API](developer/rest-api.md)
+- [GraphQL API](developer/graphql.md)
+- [Sample Data and Test Builders](developer/sample-data.md)
+- [Port Sync (internal)](developer/port-sync.md)
+- [Style Guide](developer/style-guide.md)
+
+External:
+
+- [PyPI package](https://pypi.org/project/netbox-wdm/)
 - [GitHub repository](https://github.com/jsenecal/netbox-wdm)
 - [Issue tracker](https://github.com/jsenecal/netbox-wdm/issues)
+
+## Status
+
+netbox-wdm is alpha software. The data model and REST API may change between
+0.x releases. The plugin requires NetBox 4.5 or later.

--- a/docs/user/circuit-trace.md
+++ b/docs/user/circuit-trace.md
@@ -1,0 +1,74 @@
+# Circuit Trace Visualisation
+
+Each `WdmCircuit` detail page has a **Trace** tab that renders an interactive
+horizontal flow diagram of every wavelength path attached to the circuit.
+The same renderer powers the per-channel **Trace** tab on `WdmChannel` detail
+pages.
+
+## What you see
+
+The diagram is an SVG canvas with zoom and pan support, drawn by D3.js. For
+each path attached to the circuit:
+
+- **Devices** are NetBox-style boxes. WDM nodes get a teal header; patch
+  panels and other intermediate devices get a purple header.
+- **Ports** sit flush with the device edges. Channel front ports
+  (MUX/DEMUX) appear on the client side of WDM nodes; trunk rear ports
+  appear on the trunk side.
+- **Cables** are drawn between consecutive devices and use the
+  `Cable.color` field for their stroke colour.
+- **Internal routing** (PortMappings, channel-to-COM links, ROADM
+  pass-through) is shown as faint dashed bezier curves so the inside of
+  each device is legible.
+- A central **badge** at each cable hop fans cables in and out in an
+  hourglass pattern when several wavelengths share the same physical run.
+
+The visual conventions follow `docs/developer/style-guide.md`; CSS custom
+properties keep the diagram in sync with NetBox dark and light modes
+automatically.
+
+## Interactivity
+
+Hovering or tapping a port highlights the full wavelength path that passes
+through it. Highlighting includes:
+
+- The full chain of cables, internal links, and port boxes along the path.
+- For shared ports such as COM rear ports or patch panel ports, **every**
+  path that passes through that port lights up at once.
+- For per-channel ports (MUX or DEMUX on a specific channel), only that
+  channel's path highlights.
+
+When a trace data set is empty (the circuit has no attached paths) the tab
+shows an empty state. The data sent to the front end is the
+`ChannelTraceData` dataclass, serialised as JSON in the template context as
+`trace_data_list_json`.
+
+## How the data is built
+
+The Django view `WdmCircuitTraceView` (and the per-channel
+`WdmChannelTraceView`) call `_build_trace_data_for_path()` to produce the
+JSON. For each path the function:
+
+1. Loads every `WdmWavelengthPathChannel` row in `sequence` order.
+2. Builds a `PathElement` per WDM node, capturing names, URLs, and the
+   client MUX/DEMUX ports.
+3. For each adjacent pair of nodes, calls `_trace_cable_segment` to follow
+   the trunk cable chain and collect every cable, rear port, and front port
+   along the way.
+4. For multi-TX nodes (ROADMs) `_trace_cable_segment` also picks the
+   correct TX rear port by checking which one's cable chain reaches the next
+   node.
+
+The resulting `ChannelTraceData` mirrors the dataclass in
+`netbox_wdm/dataclasses.py` and is rendered by `circuit-trace.ts`.
+
+## Limitations
+
+- The renderer assumes path entries follow physical cabling. If signals
+  have not yet rebuilt the wavelength path after a recent change, the
+  trace can be momentarily empty; reload after a few seconds.
+- A circuit with hundreds of paths can be slow to render. Consider
+  splitting bonded services into multiple circuits if they grow that large.
+- The visualisation is read-only; it has no editing affordances. Use the
+  Wavelength Editor or the cable plant tools in NetBox to modify the
+  underlying data.

--- a/docs/user/circuits.md
+++ b/docs/user/circuits.md
@@ -1,0 +1,103 @@
+# Wavelength Paths and Circuits
+
+Once WDM nodes are cabled to each other (directly, through patch panels, or
+through ROADMs), netbox-wdm auto-discovers the **wavelength paths** between
+them and lets you group those paths into **circuits** for service tracking.
+
+## Wavelength paths
+
+A `WdmWavelengthPath` represents one end-to-end run of a single ITU channel
+across the cable plant.
+
+| Field | Notes |
+|-------|-------|
+| `grid_position` | The shared grid_position across every channel on the path |
+| `wavelength_nm` | Wavelength of the path |
+| `is_complete` | True when both endpoints have at least one client port assigned |
+| `is_active` | True when every cable in the path has status `connected` and the path has at least 2 hops |
+| `is_valid` | False when the path traverses a TX-to-TX miscable |
+
+The through table `WdmWavelengthPathChannel` orders the channels along the
+path by integer `sequence` (0-indexed). Paths preserve direction: in a duplex
+topology you get one path for A-to-B and a separate path for B-to-A.
+
+## How paths are discovered
+
+Whenever a relevant signal fires (cable created or deleted, channel saved,
+port mapping changed) the plugin schedules `rebuild_wavelength_paths_for_node`
+on transaction commit for every affected node. That function:
+
+1. Iterates each unique `grid_position` on the node.
+2. Calls `trace_wavelength_path()` to walk the cable plant. The tracer first
+   walks backward via RX ports to find the **origin** node, then walks
+   forward via TX ports collecting every hop. It tries every TX rear port on
+   multi-degree nodes (ROADMs) so pass-through directions are honoured.
+3. Position-matches duplex (multi-terminated) cables using `cable_end` A/B
+   indexes so the right fibre is followed.
+4. Persists the result as a `WdmWavelengthPath` plus one
+   `WdmWavelengthPathChannel` per hop, reusing any existing path object that
+   already has the same channel sequence.
+
+Path discovery is fully automatic; there is no UI button to trigger a
+rebuild.
+
+### Validity errors
+
+`is_valid=False` is set when the trace detects that a TX rear port on one
+side connects to a TX rear port on the other side (i.e. a wiring error in
+the cable plant rather than a configuration issue). The path is still saved
+so it appears in the UI and can be inspected, but the visualisation flags it
+as invalid.
+
+`is_complete=False` is set when neither the first nor the last hop has a
+client port assigned. This is normal for under-construction services.
+
+`is_active=False` is set when at least one cable along the path has a
+non-`connected` status, or when the path has fewer than two hops.
+
+## Circuits
+
+A `WdmCircuit` is a logical service grouping over one or more wavelength
+paths. Use it to label customer services, lab tests, or internal links.
+
+| Field | Notes |
+|-------|-------|
+| `name` | Free-form, e.g. `MTL-TOR-100G-01` |
+| `status` | `planned`, `staged`, `active`, `decommissioned` |
+| `wavelength_paths` | M2M to `WdmWavelengthPath` |
+| `tenant` | Optional FK to `tenancy.Tenant` |
+| `description` / `comments` | Free text |
+
+Bidirectional services typically attach **both** wavelength paths (A-to-B
+and B-to-A). Bonded services attach more than one wavelength's worth of
+paths.
+
+### Decommission lifecycle
+
+When a circuit transitions to `decommissioned`, every channel on every
+attached wavelength path is reset to `available` status, and the M2M is
+cleared. Other lifecycle transitions are no-ops on channel status.
+
+This is implemented in `WdmCircuit.save()`.
+
+## PROTECT guards on channels
+
+When a channel's status is `active` or `reserved`, the
+[Wavelength Editor](wavelength-editor.md) and the `apply-mapping` API refuse
+to remap its front ports. To remap, first move the channel to `available` or
+remove the encompassing circuit.
+
+## Per-cable visibility
+
+The plugin registers a `CableWdmCircuitsPanel` template extension. Open any
+`dcim.Cable` detail page and the right column lists every WDM circuit whose
+wavelength paths traverse this cable. This works both for client patch
+cables (terminated on FrontPorts) and for trunk cables (terminated on
+RearPorts of WdmLinePorts).
+
+## See also
+
+- [Circuit Trace Visualisation](circuit-trace.md) for the interactive flow
+  diagram on the WdmCircuit detail page.
+- [Wavelength Path Tracing](../developer/path-tracing.md) for the algorithm
+  internals and the duplex/single-fibre fibre-following logic.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,0 +1,126 @@
+# Getting Started
+
+This page walks through installing the plugin, creating a first WDM profile on
+an existing DeviceType, and verifying that channels are auto-populated when a
+device of that type is created.
+
+## Requirements
+
+- NetBox 4.5 or later
+- Python 3.12, 3.13, or 3.14
+- PostgreSQL with PostGIS (the standard NetBox database)
+
+## Install
+
+Install the package from PyPI:
+
+```bash
+pip install netbox-wdm
+```
+
+Enable the plugin in your NetBox `configuration.py`:
+
+```python
+PLUGINS = ["netbox_wdm"]
+```
+
+Apply migrations and collect static files:
+
+```bash
+cd /opt/netbox/netbox
+python manage.py migrate
+python manage.py collectstatic --no-input
+```
+
+Restart NetBox (gunicorn, granian, or your service of choice). The plugin
+registers a top-level **WDM** menu with sub-items for Profiles, Nodes,
+Channels, and Circuits.
+
+## Optional: load sample data
+
+For a working demo topology, run the sample data management command. This
+creates a manufacturer, four DeviceTypes (CWDM duplex, CWDM single-fibre,
+DWDM 100 GHz, ROADM 2-degree), four topologies (two MUX pairs, MUX-to-ROADM,
+and a MUX-ROADM-MUX pass-through), and a handful of circuits.
+
+```bash
+python manage.py create_wdm_sample_data
+```
+
+To remove and recreate the sample data:
+
+```bash
+python manage.py create_wdm_sample_data --flush
+```
+
+All sample objects are tagged `wdm-sample-data`, which is what `--flush` keys
+off.
+
+## Your first profile and node
+
+The recommended workflow is **profile first, device second**.
+
+### 1. Create a DeviceType with the right port templates
+
+In NetBox, create or pick a DeviceType for your WDM hardware. It must already
+have FrontPortTemplate, RearPortTemplate, and PortTemplateMapping records that
+match real hardware. For a CWDM 18-channel duplex MUX you typically need:
+
+- 18 FrontPortTemplates `CH1-MUX` ... `CH18-MUX`
+- 18 FrontPortTemplates `CH1-DEMUX` ... `CH18-DEMUX`
+- Two RearPortTemplates `COM-TX` and `COM-RX` with 18 positions each (plus
+  positions for any EXP / 1310 pass-through ports)
+- PortTemplateMappings linking each front port template to the matching COM
+  rear port at the channel's grid position
+
+For a single-fibre MUX you have one set of 18 `CH{n}` front ports and a single
+`COM` rear port.
+
+The plugin does not currently auto-generate port templates; see
+[Architecture](../developer/architecture.md) for context on how port templates
+are consumed.
+
+### 2. Create a WDM profile on the DeviceType
+
+Navigate to **WDM > Profiles > Add**. Set:
+
+- **Device type:** the DeviceType you just prepared.
+- **Node type:** Terminal MUX, OADM, ROADM, or Amplifier.
+- **Grid:** DWDM 100 GHz, DWDM 50 GHz, or CWDM.
+- **Fiber type:** Duplex or Single Fiber.
+
+Save. A "WDM Profile" tab now appears on the DeviceType detail page.
+
+### 3. Define channel plans
+
+On the WDM profile detail page, switch to the **Channels** tab and add one
+**Channel Plan** row per ITU channel. For each row pick the matching
+`mux_front_port_template` (and `demux_front_port_template` for duplex
+profiles).
+
+The grid_position determines the COM rear port position used for that channel
+in PortMappings. See [ITU Channel Plans](itu-grids.md) for the position-to-
+wavelength tables.
+
+### 4. Create a Device
+
+When a `dcim.Device` is created with this DeviceType, the plugin signal
+`_device_post_save` schedules a `WdmNode` to be created on transaction
+commit, copying `node_type` and `grid` from the profile.
+
+When the WdmNode is saved, `_auto_populate_channels()` fires: it iterates the
+profile's channel plans, looks up the matching FrontPort instances on the new
+device by name, and bulk-creates one `WdmChannel` per plan row with the
+`mux_front_port` and `demux_front_port` foreign keys filled in.
+
+Verify by opening the device's WDM Node detail page (linked from the Device
+detail page) and checking that the **Channels** tab lists every plan row.
+
+## Next steps
+
+- For a ROADM you can now use the [Wavelength Editor](wavelength-editor.md) to
+  assign client ports to channels.
+- Cable the device's `LINE-*` rear ports to other WDM devices (directly or
+  through patch panels) and the plugin will auto-discover
+  [wavelength paths](circuits.md).
+- Group paths into circuits to track end-to-end services.

--- a/docs/user/itu-grids.md
+++ b/docs/user/itu-grids.md
@@ -1,0 +1,86 @@
+# ITU Channel Plans
+
+netbox-wdm ships with three built-in channel grids. The grid is set on each
+[WDM profile](wdm-profiles.md) and propagated to every WdmNode created from
+that profile. The grid drives both the channel labels (e.g. `C32`,
+`CWDM-1310`) and the wavelength assigned to each grid position.
+
+## Grids supported
+
+| Grid key | Display name | Channels | Spacing |
+|---------|--------------|----------|---------|
+| `dwdm_100ghz` | DWDM C-band 100 GHz | 44 | 100 GHz |
+| `dwdm_50ghz`  | DWDM C-band 50 GHz | 88 | 50 GHz |
+| `cwdm`        | CWDM | 18 | 20 nm |
+
+The constants are defined in `netbox_wdm/wdm_constants.py`. Wavelengths are
+computed from frequency for DWDM grids and held as a fixed list for CWDM.
+
+## How grid_position maps to a channel
+
+The `grid_position` field on `WdmChannelPlan` and `WdmChannel` is a 1-based
+integer that indexes into the grid's channel list. The plugin uses
+`get_channel_info(grid, position)` to look up the matching `(label,
+wavelength_nm)` tuple.
+
+`grid_position` also drives the `rear_port_position` value used in
+PortMappings. This is what lets multiple channels share a single COM rear
+port: each channel's PortMapping points at the same rear_port but carries a
+different `rear_port_position`. EXP and 1310 pass-through ports are
+positioned **after** the channel positions on the same COM rear port.
+
+## DWDM 100 GHz
+
+44 channels starting from 192.10 THz, with 100 GHz spacing. Labels are
+`C21` through `C64` (the ITU C-band convention).
+
+| Position | Label | Frequency (THz) | Wavelength (nm, approx) |
+|----------|-------|-----------------|-------------------------|
+| 1 | C21 | 192.10 | 1560.61 |
+| 2 | C22 | 192.20 | 1559.79 |
+| ... | ... | ... | ... |
+| 44 | C64 | 196.40 | 1526.44 |
+
+Wavelengths are computed as `c / freq_thz` and rounded to two decimal places
+using `Decimal` arithmetic so values are stable across processes.
+
+## DWDM 50 GHz
+
+88 channels, 50 GHz spacing, labels alternate between `C{n}` and `C{n}.5`.
+Position 1 starts at 192.10 THz (label `C21`), position 2 is 192.15 THz
+(label `C21.5`), and so on through position 88.
+
+## CWDM
+
+18 channels with a fixed 20 nm spacing.
+
+| Position | Label | Wavelength (nm) |
+|----------|-------|-----------------|
+| 1 | CWDM-1270 | 1270 |
+| 2 | CWDM-1290 | 1290 |
+| 3 | CWDM-1310 | 1310 |
+| 4 | CWDM-1330 | 1330 |
+| ... | ... | ... |
+| 18 | CWDM-1610 | 1610 |
+
+## Choosing a grid
+
+- **CWDM:** cheapest optics, widest spacing, no temperature stabilisation.
+  Best for fixed-wavelength access plant or short metro spans. Limited to 18
+  channels and not amplifier-friendly outside the C-band subset.
+- **DWDM 100 GHz:** the workhorse for metro and regional. 44 channels in the
+  C-band with off-the-shelf coloured optics.
+- **DWDM 50 GHz:** double the channels at half the spacing. Used when 100
+  GHz is exhausted or when running coherent muxponders that fit comfortably
+  in a 50 GHz slot.
+
+You cannot change a profile's grid after channel plans exist; either remove
+the channel plans first, or create a new profile.
+
+## Adding a new grid
+
+The grid list is hard-coded in `wdm_constants.py` and the
+`WdmGridChoices` ChoiceSet. To add another (for example L-band 100 GHz),
+extend both: append the grid to `WDM_GRIDS`, add a key to `WdmGridChoices`,
+and update the migrations if you keep CHOICES literals in `models.py`. There
+is no runtime customisation hook for grids today.

--- a/docs/user/wavelength-editor.md
+++ b/docs/user/wavelength-editor.md
@@ -1,0 +1,104 @@
+# Wavelength Editor (ROADM)
+
+The Wavelength Editor is a TypeScript UI for assigning channels to client
+front ports on a ROADM in real time. It is exposed as a tab on every WDM Node
+of `node_type=roadm`. Fixed nodes (terminal MUX, OADM, amplifier) do not show
+the tab because their channel-to-port mapping is hardware determined.
+
+## Where to find it
+
+Open the WDM Node detail page for a ROADM and switch to the **Wavelength
+Editor** tab. The tab is hidden when:
+
+- the node's type is not ROADM, or
+- the user lacks `netbox_wdm.change_wdmchannel` permission.
+
+Hitting the URL directly when the node is not a ROADM returns 404.
+
+## What you see
+
+The editor renders a table of every channel on the node, sorted by
+`grid_position`. Each row shows:
+
+- The ITU label and wavelength.
+- A dropdown of available client front ports for the **MUX** column (the TX
+  side of duplex profiles).
+- A dropdown of available client front ports for the **DEMUX** column (the
+  RX side; hidden for single-fibre ROADMs).
+- The current channel status.
+- The wavelength service name, if any service currently uses this channel.
+
+The DEMUX column only appears when the linked WDM profile reports
+`fiber_type=duplex`. For single-fibre profiles the editor shows MUX-only
+assignments.
+
+## Editing rules
+
+The editor enforces the same rules as the REST API:
+
+- **Channel status guard.** A channel whose status is `active` or `reserved`
+  cannot be remapped. The validator returns an error and the dropdown is
+  effectively read-only.
+- **Port uniqueness.** A given FrontPort cannot be assigned to two channels
+  in the same submission.
+- **Optimistic concurrency.** When the editor loads it captures the node's
+  `last_updated` timestamp. If the node has been touched in the meantime the
+  apply call returns `409 Conflict` and the editor prompts a reload.
+
+These rules live in `WdmNode.validate_channel_mapping()` and the
+`apply-mapping` endpoint in `netbox_wdm/api/views.py`.
+
+## Apply
+
+The editor batches every changed row into a single payload and submits it to
+the `apply-mapping` REST action:
+
+```
+POST /api/plugins/wdm/wdm-nodes/{id}/apply-mapping/
+```
+
+with body shape:
+
+```json
+{
+  "last_updated": "2026-04-27 12:34:56.789012+00:00",
+  "mapping": {
+    "<channel_pk>": {"mux": <front_port_pk_or_null>, "demux": <front_port_pk_or_null>}
+  }
+}
+```
+
+The endpoint runs in a single transaction and:
+
+1. Validates against the rules above. On any error it aborts with HTTP 400
+   and a list of error strings.
+2. Updates the affected `WdmChannel.mux_front_port_id` and
+   `demux_front_port_id` columns via `bulk_update`.
+3. Deletes stale `dcim.PortMapping` rows for ports that are no longer
+   assigned, and bulk-creates new ones for the new assignments. Each new
+   mapping uses `front_port_position=1` and
+   `rear_port_position=channel.grid_position`.
+4. Retraces every `dcim.CablePath` that traverses the node's line port rear
+   ports.
+
+Counts of added, removed, and changed channels come back in the response,
+along with the new `last_updated` timestamp so the editor can keep submitting
+without reloading.
+
+## Undo, redo, and dirty state
+
+The TypeScript editor maintains an undo stack of every change since load.
+Buttons let operators step backward or forward; the **Save** button is only
+enabled while the model is dirty. Cancelling discards the stack and reloads
+from the server.
+
+## Frontend details
+
+The editor lives in `netbox_wdm/static/netbox_wdm/src/wavelength-editor.ts`
+and is built with esbuild (see `make ts-build`). The Django view that hosts
+it is `WdmNodeWavelengthEditorView`; it serialises the channel and
+available-port lists into an `editor_config_json` blob the page loads at
+boot.
+
+For frontend conventions (CSS variables, badges, toolbars, accessibility),
+see the [Style Guide](../developer/style-guide.md).

--- a/docs/user/wdm-nodes.md
+++ b/docs/user/wdm-nodes.md
@@ -1,0 +1,102 @@
+# WDM Nodes
+
+A **WDM node** is the per-device instance of a [WDM profile](wdm-profiles.md).
+It is a one-to-one overlay on `dcim.Device` and owns the actual `WdmChannel`
+and `WdmLinePort` rows for that device.
+
+## Lifecycle
+
+Nodes are normally created automatically. When a `dcim.Device` is saved and
+its DeviceType has a WDM profile, a `post_save` signal handler schedules a
+`WdmNode` to be created on transaction commit, copying `node_type` and `grid`
+from the profile.
+
+You can also create a WdmNode manually from **WDM > Nodes > Add**, selecting
+the device. This is useful when a device was imported before its DeviceType
+got a profile.
+
+When a WdmNode is created, `_auto_populate_channels()` runs:
+
+1. The profile's `WdmChannelPlan` rows are loaded.
+2. For each plan, the plugin looks up `FrontPort` instances on the new device
+   by name (matching the plan's `mux_front_port_template.name` and
+   `demux_front_port_template.name`).
+3. One `WdmChannel` is bulk-created per plan, with foreign keys to the
+   matching front ports.
+
+If a front port template name does not match an existing FrontPort on the
+device (for example because port templates were renamed after device
+creation), the channel is still created with a null front port. You can fix
+this later via [Port Sync](port-sync.md).
+
+Amplifier nodes (`node_type=amplifier`) skip channel auto-population because
+amplifiers do not carry per-channel client ports.
+
+## Fields
+
+| Field | Notes |
+|-------|-------|
+| `device` | One-to-one to `dcim.Device` |
+| `node_type` | `terminal_mux`, `oadm`, `roadm`, `amplifier` |
+| `grid` | Same choices as `WdmProfile.grid` |
+| `description` | Free text |
+| `expected_port_hash` | Internal: SHA-256 of the expected PortMapping state |
+| `port_sync_valid` | Internal: True when actual PortMappings match expected hash |
+
+The two internal fields are explained in [Port Sync](port-sync.md).
+
+## Fixed vs. ROADM nodes
+
+The model distinguishes between **fixed** and **ROADM** nodes via the
+`is_fixed` property:
+
+- `is_fixed = True` for `terminal_mux`, `oadm`, and `amplifier`. The
+  channel-to-port assignments and line port configuration are hardware
+  determined; modifying them is rejected at `save()` time.
+- `is_fixed = False` for `roadm`. Channel assignments can be remapped at
+  runtime, and the [Wavelength Editor](wavelength-editor.md) is exposed as
+  a tab on the node detail page.
+
+For fixed nodes, only `WdmChannel.status` (Available / Reserved / Active) can
+be changed after creation.
+
+## Detail page
+
+The WDM Node detail page shows:
+
+- A header with port-sync status. When out of sync, a banner lets operators
+  trigger Sync Now.
+- A stacked status bar across all channels showing
+  active / reserved / available split, broken into connected and disconnected
+  buckets (a channel is "connected" when at least one of its MUX or DEMUX
+  front ports has a cable).
+- A **Channels** tab listing every `WdmChannel` on the node.
+- A **Line Ports** tab listing every `WdmLinePort` (the trunk RearPort
+  designations).
+- A **Wavelength Editor** tab (ROADM nodes only) for live channel reassignment.
+
+## Line ports
+
+`WdmLinePort` records identify which of the device's `RearPort` instances
+carry trunk wavelengths and which direction they belong to.
+
+| Field | Notes |
+|-------|-------|
+| `wdm_node` | Parent node |
+| `rear_port` | FK to `dcim.RearPort` (must belong to the same device) |
+| `direction` | `common`, `east`, or `west` |
+| `role` | `tx`, `rx`, or `bidi` |
+
+A duplex MUX has two line ports: COM-TX (role `tx`) and COM-RX (role `rx`),
+both `direction=common`. A single-fibre MUX has one line port with
+`role=bidi`. A 2-degree ROADM has four: `(east, tx)`, `(east, rx)`,
+`(west, tx)`, `(west, rx)`.
+
+Constraints prevent two line ports on the same node from sharing a rear port,
+and from having the same direction-role pair.
+
+## Bulk operations
+
+The list view provides bulk import and bulk delete. Bulk import accepts a CSV
+or YAML payload with `device`, `node_type`, `grid`, and `description`
+columns.

--- a/docs/user/wdm-profiles.md
+++ b/docs/user/wdm-profiles.md
@@ -1,0 +1,90 @@
+# WDM Profiles
+
+A **WDM profile** is the blueprint that turns a generic NetBox DeviceType into
+a WDM-aware DeviceType. It is a one-to-one overlay on `dcim.DeviceType`,
+defining grid choice, node type, and fibre topology.
+
+## Why a profile
+
+NetBox's DeviceType already stores port templates and mechanical layout. The
+WDM profile adds the optical metadata that NetBox does not model natively:
+
+- Which ITU grid this hardware uses (DWDM 100 GHz, DWDM 50 GHz, or CWDM).
+- Whether it is a terminal MUX, an OADM, a ROADM, or an inline amplifier.
+- Whether each channel uses a duplex pair (separate MUX/DEMUX fibres) or a
+  single bidirectional fibre.
+- Which FrontPortTemplate corresponds to each channel's MUX and DEMUX side.
+
+When a device of this DeviceType is later created, the profile's child rows
+(channel plans) are used to bulk-create one `WdmChannel` per ITU position on
+the resulting `WdmNode`.
+
+## Fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `device_type` | yes | One-to-one to `dcim.DeviceType` |
+| `node_type` | yes | `terminal_mux`, `oadm`, `roadm`, or `amplifier` |
+| `grid` | yes | `dwdm_100ghz` (44 ch), `dwdm_50ghz` (88 ch), or `cwdm` (18 ch) |
+| `fiber_type` | yes | `duplex` (default) or `single_fiber` |
+| `description` | no | Free-form text |
+
+## Channel plans
+
+Each profile owns zero or more `WdmChannelPlan` rows. A channel plan is the
+template entry for one ITU channel, with these fields:
+
+| Field | Notes |
+|-------|-------|
+| `profile` | Parent WDM profile |
+| `grid_position` | Integer position in the ITU grid (1-based, see [ITU Channel Plans](itu-grids.md)) |
+| `wavelength_nm` | Wavelength for the position; computed for DWDM, fixed for CWDM |
+| `label` | Display label, e.g. `C32`, `C32.5`, `CWDM-1310` |
+| `mux_front_port_template` | FK to a `dcim.FrontPortTemplate` on the same DeviceType (the MUX side) |
+| `demux_front_port_template` | FK to a `dcim.FrontPortTemplate` on the same DeviceType (the DEMUX side); leave empty for single-fibre profiles |
+
+Database constraints prevent the same DeviceType from re-using a wavelength,
+grid position, or front port template across multiple channel plans.
+
+## Creating a profile
+
+From the NetBox UI:
+
+1. Navigate to **WDM > Profiles > Add**.
+2. Pick the DeviceType. A DeviceType can only have one profile.
+3. Pick `node_type`, `grid`, and `fiber_type`.
+4. Save. The profile detail page opens with an empty **Channels** tab.
+5. Switch to the **Channels** tab and add one row per ITU position you wish to
+   provision, picking the matching FrontPortTemplate(s).
+
+Profiles also appear on the DeviceType detail page under a **WDM Profile**
+tab; this tab is only visible when a profile exists.
+
+## Editing constraints
+
+Once channels exist on a `WdmNode`, the linked profile's channel plans should
+be considered fairly stable; the plugin does not currently auto-propagate
+template changes onto existing devices.
+
+There are two safe operations:
+
+- Adding new channel plan rows. Existing devices keep their existing channels;
+  newly created devices pick up the larger set.
+- Editing free-form fields (`description`).
+
+For changes that affect port assignments on already-deployed devices, prefer
+to remap on each `WdmNode` individually rather than editing the template.
+
+## Bulk operations
+
+The list view exposes bulk delete and bulk import. Bulk import accepts a CSV
+or YAML payload with the `device_type`, `node_type`, `grid`, and `fiber_type`
+columns. Channel plan rows must be added separately.
+
+## Where to look in code
+
+- `netbox_wdm/models.py` defines `WdmProfile` and `WdmChannelPlan`.
+- `netbox_wdm/signals.py:_device_post_save` is what creates a `WdmNode` when a
+  device is added to a DeviceType that has a profile.
+- `netbox_wdm/models.py:WdmNode._auto_populate_channels` materialises the
+  channel plan rows into concrete `WdmChannel` rows on a new node.


### PR DESCRIPTION
Substantive expansion of the documentation site, generated by a per-plugin exploration pass that traced models, views, REST API, backends, and management commands. Covers user workflows, configuration references, REST API, and developer guides.

Drafted as PRs to land iteratively -- review piece by piece, edit / drop pages where the prose doesn't match operator reality, trim things better suited to code comments. The agent that drafted this had less context than you do; treat as a starting point.

ASCII-only output, no AI / Claude attribution. Conventional-commits PR title.