### PR TITLE
fix(signals): ignore PortTemplateMapping in port mapping signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Creating a FrontPort on a DeviceType no longer crashes with `AttributeError: 'PortTemplateMapping' object has no attribute 'device'`. NetBox's `FrontPortFormMixin._save_m2m` sends `post_save` with a hardcoded `sender=PortMapping` even when the instance is a `PortTemplateMapping`; the WDM signal handler now ignores template-level instances. ([#22](https://github.com/jsenecal/netbox-wdm/issues/22))
+
 ## [0.2.2] - 2026-04-28
 
 ### Added

--- a/netbox_wdm/signals.py
+++ b/netbox_wdm/signals.py
@@ -120,7 +120,15 @@ def _lineport_changed(sender: type, instance: Any, **kwargs: Any) -> None:
 
 def _portmapping_changed(sender: type, instance: Any, **kwargs: Any) -> None:
     """Rebuild wavelength paths and recheck port sync when a port mapping changes."""
+    from dcim.models import PortMapping
+
     from .models import WdmNode
+
+    # NetBox's FrontPortFormMixin._save_m2m sends post_save with sender=PortMapping
+    # even when the instance is a PortTemplateMapping (DeviceType-level template).
+    # Templates have no live device, so there is nothing for us to rebuild.
+    if not isinstance(instance, PortMapping):
+        return
 
     try:
         node = WdmNode.objects.get(device=instance.device)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,28 @@
+"""Tests for signal handlers."""
+
+import pytest
+from dcim.models import PortMapping
+from dcim.models.device_component_templates import PortTemplateMapping
+from django.db.models.signals import post_save
+
+
+@pytest.mark.django_db
+def test_portmapping_signal_ignores_template_mapping_instance(dt_cwdm_dx):
+    """Regression test for issue #22.
+
+    NetBox's FrontPortFormMixin._save_m2m calls post_save.send with a hardcoded
+    sender=PortMapping even when the instance is a PortTemplateMapping (created
+    from a FrontPortTemplateForm on a DeviceType). PortTemplateMapping has no
+    `device` attribute, so the signal handler must short-circuit instead of
+    raising AttributeError.
+    """
+    template_mapping = PortTemplateMapping.objects.filter(device_type=dt_cwdm_dx).first()
+    assert template_mapping is not None, "fixture should create at least one PortTemplateMapping"
+
+    post_save.send(
+        sender=PortMapping,
+        instance=template_mapping,
+        created=True,
+        raw=False,
+        update_fields=None,
+    )


### PR DESCRIPTION
## Summary
- Stop `_portmapping_changed` from crashing when NetBox sends `post_save(sender=PortMapping)` with a `PortTemplateMapping` instance (the same code path used by `FrontPortTemplateForm` on a DeviceType).
- Adds a regression test that reproduces the original `AttributeError` from issue #22.

## Changes
- `netbox_wdm/signals.py`: `_portmapping_changed` now returns early when `instance` is not a real `PortMapping`. Inline comment documents NetBox's hardcoded `sender=PortMapping` in `dcim/forms/mixins.py::FrontPortFormMixin._save_m2m`.
- `tests/test_signals.py`: new regression test that fires `post_save.send(sender=PortMapping, instance=<PortTemplateMapping>)` and verifies it does not raise.
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]` referencing issue #22.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/test_signals.py tests/test_port_sync.py` passes (24/24)
- [x] `pytest tests/test_trace.py tests/test_trace_duplex.py` passes (26/26)
- [x] New regression test fails on `main` with the exact `AttributeError` from the bug report and passes after the fix

## Related
Fixes: #22