### PR TITLE
build!: raise NetBox min_version to 4.6.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.6.6", "4.6.8"]
+        netbox: ["4.6.8"]
     services:
       postgres:
         image: postgis/postgis:17-3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.5.8", "4.5.10"]
+        netbox: ["4.6.6", "4.6.8"]
     services:
       postgres:
         image: postgis/postgis:17-3.4
@@ -170,7 +170,7 @@ jobs:
           pytest tests/ -v --tb=short --cov=netbox_wdm --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && matrix.netbox == '4.5.10'
+        if: matrix.python == '3.13' && matrix.netbox == '4.6.8'
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** raised the minimum supported NetBox version from 4.5.0 to 4.6.6. Upcoming changes rely on profile-aware `link_peers` (NetBox 4.6.0) and the `FrontPortFormMixin._save_m2m` template-mapping `post_save` fix in NetBox 4.6.6 (see the Fixed entry below). ([#38](https://github.com/jsenecal/netbox-wdm/issues/38))
+
 ### Fixed
 
 - Creating a FrontPort on a DeviceType no longer crashes with `AttributeError: 'PortTemplateMapping' object has no attribute 'device'`. NetBox's `FrontPortFormMixin._save_m2m` sends `post_save` with a hardcoded `sender=PortMapping` even when the instance is a `PortTemplateMapping`; the WDM signal handler now ignores template-level instances. ([#22](https://github.com/jsenecal/netbox-wdm/issues/22))

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # netbox-wdm
 
-> A [NetBox](https://github.com/netbox-community/netbox) 4.5+ plugin for WDM (Wavelength Division Multiplexing) device management.
+> A [NetBox](https://github.com/netbox-community/netbox) 4.6.6+ plugin for WDM (Wavelength Division Multiplexing) device management.
 
 [![PyPI](https://img.shields.io/pypi/v/netbox-wdm.svg)](https://pypi.org/project/netbox-wdm/)
 [![Python](https://img.shields.io/pypi/pyversions/netbox-wdm.svg)](https://pypi.org/project/netbox-wdm/)
-[![NetBox](https://img.shields.io/badge/NetBox-4.5%2B-success.svg)](https://github.com/netbox-community/netbox)
+[![NetBox](https://img.shields.io/badge/NetBox-4.6.6%2B-success.svg)](https://github.com/netbox-community/netbox)
 [![CI](https://github.com/jsenecal/netbox-wdm/actions/workflows/ci.yml/badge.svg)](https://github.com/jsenecal/netbox-wdm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/jsenecal/netbox-wdm/branch/main/graph/badge.svg)](https://codecov.io/gh/jsenecal/netbox-wdm)
 [![Documentation](https://img.shields.io/badge/docs-jsenecal.github.io-blue)](https://jsenecal.github.io/netbox-wdm/)
@@ -33,9 +33,10 @@ Manages ITU channel plans, channel-to-port assignments, trunk port identificatio
 
 ## Compatibility
 
-| Plugin version | NetBox version | Python    |
-|----------------|----------------|-----------|
-| 0.2.x          | 4.5            | 3.12-3.14 |
+| Plugin version    | NetBox version | Python    |
+|-------------------|----------------|-----------|
+| main (unreleased) | 4.6.6+         | 3.12-3.14 |
+| 0.2.x             | 4.5            | 3.12-3.14 |
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,4 +72,4 @@ External:
 ## Status
 
 netbox-wdm is alpha software. The data model and REST API may change between
-0.x releases. The plugin requires NetBox 4.5 or later.
+0.x releases. The plugin requires NetBox 4.6.6 or later.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -8,7 +8,7 @@ reference docs for each step.
 
 ## Requirements
 
-- NetBox 4.5 or later
+- NetBox 4.6.6 or later
 - Python 3.12, 3.13, or 3.14
 - PostgreSQL with PostGIS (the standard NetBox database)
 

--- a/netbox_wdm/__init__.py
+++ b/netbox_wdm/__init__.py
@@ -15,7 +15,7 @@ class NetBoxWDMConfig(PluginConfig):
     author = "Jonathan Senecal"
     author_email = "contact@jonathansenecal.com"
     base_url = "wdm"
-    min_version = "4.5.0"
+    min_version = "4.6.6"
     default_settings = {}
 
     def ready(self):


### PR DESCRIPTION
## Summary
- Raises the plugin's NetBox floor from 4.5.0 to 4.6.6, prerequisite for the module-scoped WDM series (#37).
- The series relies on profile-aware link_peers (NetBox 4.6.0) and the FrontPortFormMixin._save_m2m template-mapping post_save fix (NetBox 4.6.6).
- Breaking for installations on NetBox 4.5.x-4.6.5.

## Changes
- netbox_wdm/__init__.py: min_version 4.5.0 -> 4.6.6
- README.md: tagline, NetBox badge, and compatibility matrix (new main/unreleased row)
- docs/index.md, docs/user/getting-started.md: requirement lines now say NetBox 4.6.6 or later
- CHANGELOG.md: breaking floor change noted under [Unreleased]
- .github/workflows/ci.yml: test matrix 4.5.8/4.5.10 -> 4.6.8 (latest 4.6.x only; the 4.6.6 floor is enforced by PluginConfig at startup). Python legs unchanged at 3.12/3.13/3.14, matching NetBox 4.6.x support.

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [ ] pytest locally -- not meaningful for this change: the local devcontainer runs NetBox 4.6.3 (below the new floor) and tests import the editable-installed checkout; CI on the NetBox 4.6.8 matrix is the real verification
- [x] No new/changed runtime behavior beyond the version constant; no tests apply
- [x] No schema change / migration
- [x] Docs updated (README, CHANGELOG, zensical pages)

## Related
Refs: #38