### PR TITLE
feat(trace): make the trace hop cap a plugin setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `max_trace_hops` plugin setting (default 20): the cable-chain walk cap used by wavelength path discovery and circuit trace rendering is now configurable via `PLUGINS_CONFIG`, and hitting the cap logs a warning instead of silently returning an incomplete path. ([#43](https://github.com/jsenecal/netbox-wdm/issues/43))
+
 - Module-scoped WDM overlay: `WdmProfile.module_type`, `WdmChannel.module`, and `WdmLinePort.module` let a `dcim.ModuleType` (rather than only a `DeviceType`) carry a WDM profile, so cassette-style modular chassis get one independent set of channels and line ports per installed module.
 - WDM Profile tab on `ModuleType` detail pages, matching the existing DeviceType tab: profile summary, channel plans, and line port plans.
 - Full CRUD for `WdmLinePortPlan`: `wdm-line-port-plans` REST route, `wdmlineportplan` detail/edit/delete views, and a Line Port Plans card on the WDM Profile and DeviceType/ModuleType WDM Profile tab pages.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ In your NetBox `configuration.py`:
 PLUGINS = ["netbox_wdm"]
 ```
 
+### Configuration
+
+Optional settings, with their defaults, in `PLUGINS_CONFIG`:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_wdm": {
+        # Maximum number of hops the cable-chain walker follows between two
+        # WDM nodes (path discovery and circuit trace rendering). Raise this
+        # if legitimate chains pass through more intermediate devices; a
+        # warning is logged when the cap truncates a trace.
+        "max_trace_hops": 20,
+    },
+}
+```
+
 Apply migrations:
 
 ```bash

--- a/docs/developer/path-tracing.md
+++ b/docs/developer/path-tracing.md
@@ -121,7 +121,8 @@ in the chain still pick the right fibre.
 The `visited` set tracks every rear port the walk has touched, so a
 cyclic patch plant (loopback into the same PP) terminates instead of
 looping forever. The outer `_get_far_end_node` also caps total hops at
-20.
+the `max_trace_hops` plugin setting (default 20) and logs a warning
+when the cap truncates a walk.
 
 ## Validity flags
 
@@ -174,8 +175,9 @@ paths exist.
 
 ## Performance characteristics
 
-- The walk is bounded at 20 hops, so worst-case node-traversal is O(20)
-  per grid position.
+- The walk is bounded at `max_trace_hops` hops (plugin setting, default
+  20), so worst-case node-traversal is O(max_trace_hops) per grid
+  position.
 - Each cable lookup runs a few `CableTermination` queries plus a
   `RearPort` or `FrontPort` fetch. Multi-terminated cables only widen
   the per-cable work, not the hop count.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -26,6 +26,22 @@ Enable the plugin in your NetBox `configuration.py`:
 PLUGINS = ["netbox_wdm"]
 ```
 
+### Plugin settings
+
+All settings are optional; defaults are shown below.
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_wdm": {
+        "max_trace_hops": 20,
+    },
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `max_trace_hops` | `20` | Maximum number of hops the cable-chain walker follows between two WDM nodes. Both wavelength path discovery and circuit trace rendering stop after this many hops to guard against cabling loops. Raise it if legitimate chains pass through more intermediate devices (patch panels, amplifiers); when the cap truncates a trace, a warning is logged so the incomplete path is visible. |
+
 Apply migrations and collect static files:
 
 ```bash

--- a/netbox_wdm/__init__.py
+++ b/netbox_wdm/__init__.py
@@ -16,7 +16,11 @@ class NetBoxWDMConfig(PluginConfig):
     author_email = "contact@jonathansenecal.com"
     base_url = "wdm"
     min_version = "4.6.6"
-    default_settings = {}
+    default_settings = {
+        # Maximum number of hops the cable-chain walker follows between two
+        # WDM nodes before giving up (guards against cabling loops).
+        "max_trace_hops": 20,
+    }
     graphql_schema = "graphql.schema.schema"
 
     def ready(self):

--- a/netbox_wdm/testing/__init__.py
+++ b/netbox_wdm/testing/__init__.py
@@ -27,7 +27,15 @@ from .devices import (
     create_sf_mux,
     ensure_populated,
 )
-from .topologies import Topology, duplex_mux_pair, dwdm_mux_to_roadm, modular_chassis_span, mux_roadm_mux, sf_mux_pair
+from .topologies import (
+    Topology,
+    duplex_mux_pair,
+    dwdm_mux_to_roadm,
+    modular_chassis_span,
+    mux_roadm_mux,
+    sf_mux_long_chain,
+    sf_mux_pair,
+)
 
 __all__ = [
     "cable_duplex_through_pp_pair",
@@ -54,6 +62,7 @@ __all__ = [
     "ensure_populated",
     "modular_chassis_span",
     "mux_roadm_mux",
+    "sf_mux_long_chain",
     "sf_mux_pair",
     "Topology",
     "WdmDeviceBundle",

--- a/netbox_wdm/testing/topologies.py
+++ b/netbox_wdm/testing/topologies.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from dcim.models import Cable, Device, DeviceRole, DeviceType, ModuleType, Site
+from dcim.models import Cable, Device, DeviceRole, DeviceType, FrontPort, FrontPortTemplate, ModuleType, RearPort, Site
 
 from .cabling import cable_duplex_through_pp_pair, cable_through_pp_pair
 from .devices import WdmDeviceBundle, create_duplex_mux, create_patch_panel, create_roadm, create_sf_mux
@@ -119,6 +119,87 @@ def sf_mux_pair(
         name=f"{p}sf-mux-pair",
         bundles={"mux_a": mux_a, "mux_b": mux_b},
         patch_panels=[pp_a, pp_b],
+        cables=cables,
+    )
+
+
+def sf_mux_long_chain(
+    site: Site,
+    dt_sf_mux: DeviceType,
+    dt_pp: DeviceType,
+    roles: dict[str, DeviceRole],
+    passthrough_units: int,
+    name_prefix: str = "",
+) -> Topology:
+    """Create two SF MUX endpoints joined by a long chain of patch panel pass-throughs.
+
+    Each pass-through unit occupies three patch panel ports (A, B, C) wired so
+    that the trace walker consumes one discovery hop per unit:
+
+        ...RP ->(patch)-> A.FP =PM= A.RP ->(trunk)-> B.RP =PM= B.FP ->(patch)-> C.FP =PM= C.RP...
+
+    A terminal patch panel port pair then patches into the far MUX COM rear
+    port, costing one more hop, so discovering the far end takes
+    passthrough_units + 1 hops. Patch panel devices are created as needed;
+    ports are allocated sequentially across them.
+
+    Args:
+        site: Site instance for all devices.
+        dt_sf_mux: DeviceType for single-fiber MUX devices.
+        dt_pp: DeviceType for patch panels.
+        roles: Dict with keys "wdm-mux" and "fiber-pp" mapping to DeviceRole instances.
+        passthrough_units: Number of three-port pass-through units in the chain.
+        name_prefix: Optional prefix for device names.
+
+    Returns:
+        Topology with bundles keyed "mux_a" and "mux_b".
+    """
+    p = f"{name_prefix}" if name_prefix else ""
+
+    mux_a = create_sf_mux(site, dt_sf_mux, roles["wdm-mux"], f"{p}MUX-A")
+    mux_b = create_sf_mux(site, dt_sf_mux, roles["wdm-mux"], f"{p}MUX-B")
+
+    ports_needed = 3 * passthrough_units + 2
+    ports_per_panel = FrontPortTemplate.objects.filter(device_type=dt_pp).count()
+    num_panels = -(-ports_needed // ports_per_panel)
+    panels = [create_patch_panel(site, dt_pp, roles["fiber-pp"], f"{p}PP-{i:02d}") for i in range(1, num_panels + 1)]
+
+    def pp_port(index: int) -> tuple[FrontPort, RearPort]:
+        device = panels[index // ports_per_panel]
+        num = index % ports_per_panel + 1
+        fp = FrontPort.objects.get(device=device, name=f"FP-{num:02d}")
+        rp = RearPort.objects.get(device=device, name=f"RP-{num:02d}")
+        return fp, rp
+
+    cables: list[Cable] = []
+
+    def add_cable(a_term, b_term, label: str) -> None:
+        cable = Cable(type="smf-os2", status="connected", label=label, a_terminations=[a_term], b_terminations=[b_term])
+        cable.save()
+        cables.append(cable)
+
+    current_rp = mux_a.line_ports["bidi"].rear_port
+    idx = 0
+    for unit in range(1, passthrough_units + 1):
+        a_fp, a_rp = pp_port(idx)
+        b_fp, b_rp = pp_port(idx + 1)
+        c_fp, c_rp = pp_port(idx + 2)
+        idx += 3
+        add_cable(current_rp, a_fp, f"{p}chain unit {unit} entry")
+        add_cable(a_rp, b_rp, f"{p}chain unit {unit} trunk")
+        add_cable(b_fp, c_fp, f"{p}chain unit {unit} link")
+        current_rp = c_rp
+
+    end_a_fp, end_a_rp = pp_port(idx)
+    end_b_fp, end_b_rp = pp_port(idx + 1)
+    add_cable(current_rp, end_a_fp, f"{p}chain end entry")
+    add_cable(end_a_rp, end_b_rp, f"{p}chain end trunk")
+    add_cable(end_b_fp, mux_b.line_ports["bidi"].rear_port, f"{p}chain end exit")
+
+    return Topology(
+        name=f"{p}sf-mux-long-chain",
+        bundles={"mux_a": mux_a, "mux_b": mux_b},
+        patch_panels=panels,
         cables=cables,
     )
 

--- a/netbox_wdm/trace.py
+++ b/netbox_wdm/trace.py
@@ -6,14 +6,34 @@ between WDM nodes, traversing through intermediate devices (patch panels, EDFAs)
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 from dcim.models import CableTermination, FrontPort, PortMapping, RearPort
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
+from netbox.plugins import get_plugin_config
 
 from .models import WdmChannel, WdmLinePort, WdmNode, WdmWavelengthPath, WdmWavelengthPathChannel
+
+logger = logging.getLogger(__name__)
+
+
+def get_max_trace_hops() -> int:
+    """Return the configured hop cap for cable-chain walks (max_trace_hops plugin setting)."""
+    return get_plugin_config("netbox_wdm", "max_trace_hops", 20)
+
+
+def warn_max_trace_hops_reached(start_rp: RearPort, max_hops: int) -> None:
+    """Log that a cable-chain walk was truncated by the hop cap, so the incomplete path is visible."""
+    logger.warning(
+        "Cable trace from rear port %s on device %s stopped after %d hops; the traced path may be "
+        "incomplete. Raise the max_trace_hops plugin setting if the chain is legitimately longer.",
+        start_rp,
+        start_rp.device,
+        max_hops,
+    )
 
 
 @dataclass
@@ -287,8 +307,9 @@ def _get_far_end_node(rear_port: RearPort) -> tuple[WdmNode | None, Any, RearPor
     """
     visited = {rear_port.pk}
     current_rp = rear_port
+    max_hops = get_max_trace_hops()
 
-    for _ in range(20):  # max hops to prevent infinite loops
+    for _ in range(max_hops):  # bounded to prevent infinite loops
         far_rp = _resolve_rearport_cable(current_rp, visited)
         if far_rp is None:
             return None, None, None
@@ -305,6 +326,7 @@ def _get_far_end_node(rear_port: RearPort) -> tuple[WdmNode | None, Any, RearPor
         # Not a WDM node — continue from this rear port
         current_rp = far_rp
 
+    warn_max_trace_hops_reached(rear_port, max_hops)
     return None, None, None
 
 

--- a/netbox_wdm/views.py
+++ b/netbox_wdm/views.py
@@ -505,6 +505,7 @@ def _trace_cable_segment(
     from django.contrib.contenttypes.models import ContentType
 
     from .models import WdmLinePort
+    from .trace import get_max_trace_hops, warn_max_trace_hops_reached
 
     items: list[CableSegmentItem] = []
     rp_ct = ContentType.objects.get_for_model(RearPort)
@@ -620,11 +621,13 @@ def _trace_cable_segment(
         return None, ""
 
     # Start: source rear port
-    current_rp = RearPort.objects.select_related("device").get(pk=tx_lp.rear_port_id)
+    source_rp = RearPort.objects.select_related("device").get(pk=tx_lp.rear_port_id)
+    current_rp = source_rp
     _add_rp(current_rp)
 
     visited_ports: set[int] = {current_rp.pk}
-    for _hop in range(20):  # max hops
+    max_hops = get_max_trace_hops()
+    for _hop in range(max_hops):
         fresh_rp = RearPort.objects.only("pk", "cable_id").get(pk=current_rp.pk)
         if not fresh_rp.cable_id:
             break
@@ -690,6 +693,8 @@ def _trace_cable_segment(
             continue
 
         break
+    else:
+        warn_max_trace_hops_reached(source_rp, max_hops)
 
     return items
 

--- a/tests/test_trace_hop_cap.py
+++ b/tests/test_trace_hop_cap.py
@@ -1,0 +1,69 @@
+"""Regression tests for the configurable trace hop cap (issue #43).
+
+Both traversal engines used to hard-code a 20-hop cap, so a legitimate
+chain longer than that silently came back incomplete. The cap is now the
+max_trace_hops plugin setting, and hitting it logs a warning.
+"""
+
+import logging
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+
+from netbox_wdm.testing import sf_mux_long_chain
+from netbox_wdm.trace import _get_far_end_node
+from netbox_wdm.views import _trace_cable_segment
+
+
+def _plugins_config(max_trace_hops: int) -> dict:
+    """Copy of settings.PLUGINS_CONFIG with max_trace_hops set for netbox_wdm."""
+    config = {name: dict(cfg) for name, cfg in settings.PLUGINS_CONFIG.items()}
+    config.setdefault("netbox_wdm", {})["max_trace_hops"] = max_trace_hops
+    return config
+
+
+@pytest.mark.django_db
+class TestDiscoveryHopCap:
+    """Hop cap in trace._get_far_end_node (path discovery engine)."""
+
+    def test_long_chain_resolves_with_raised_cap(self, wdm_site, dt_cwdm_sf, dt_pp, wdm_roles):
+        """A 21-hop chain resolves once max_trace_hops is raised above 20 (issue #43)."""
+        topo = sf_mux_long_chain(wdm_site, dt_cwdm_sf, dt_pp, wdm_roles, passthrough_units=20)
+        start_rp = topo.bundles["mux_a"].line_ports["bidi"].rear_port
+        with override_settings(PLUGINS_CONFIG=_plugins_config(50)):
+            node, module, far_rp = _get_far_end_node(start_rp)
+        assert node == topo.bundles["mux_b"].node
+        assert module is None
+        assert far_rp == topo.bundles["mux_b"].line_ports["bidi"].rear_port
+
+    def test_cap_hit_logs_warning(self, wdm_site, dt_cwdm_sf, dt_pp, wdm_roles, caplog):
+        """Hitting the default 20-hop cap truncates discovery and logs a warning (issue #43)."""
+        topo = sf_mux_long_chain(wdm_site, dt_cwdm_sf, dt_pp, wdm_roles, passthrough_units=20)
+        start_rp = topo.bundles["mux_a"].line_ports["bidi"].rear_port
+        with caplog.at_level(logging.WARNING, logger="netbox_wdm.trace"):
+            node, module, far_rp = _get_far_end_node(start_rp)
+        assert node is None
+        assert "max_trace_hops" in caplog.text
+
+
+@pytest.mark.django_db
+class TestCableSegmentHopCap:
+    """Hop cap in views._trace_cable_segment (trace rendering engine)."""
+
+    def test_long_chain_traces_with_raised_cap(self, wdm_site, dt_cwdm_sf, dt_pp, wdm_roles):
+        """A chain needing more than 20 walk iterations completes with a raised cap (issue #43)."""
+        topo = sf_mux_long_chain(wdm_site, dt_cwdm_sf, dt_pp, wdm_roles, passthrough_units=10)
+        far_rp = topo.bundles["mux_b"].line_ports["bidi"].rear_port
+        with override_settings(PLUGINS_CONFIG=_plugins_config(50)):
+            items = _trace_cable_segment(topo.bundles["mux_a"].node, topo.bundles["mux_b"].node)
+        assert any(item.type == "rear_port" and item.id == far_rp.pk for item in items)
+
+    def test_cap_hit_logs_warning(self, wdm_site, dt_cwdm_sf, dt_pp, wdm_roles, caplog):
+        """Hitting the default cap truncates the rendered segment and logs a warning (issue #43)."""
+        topo = sf_mux_long_chain(wdm_site, dt_cwdm_sf, dt_pp, wdm_roles, passthrough_units=10)
+        far_rp = topo.bundles["mux_b"].line_ports["bidi"].rear_port
+        with caplog.at_level(logging.WARNING, logger="netbox_wdm.trace"):
+            items = _trace_cable_segment(topo.bundles["mux_a"].node, topo.bundles["mux_b"].node)
+        assert not any(item.type == "rear_port" and item.id == far_rp.pk for item in items)
+        assert "max_trace_hops" in caplog.text


### PR DESCRIPTION
## Summary

- Both traversal engines hard-coded a 20-hop cap, so a legitimately longer chain stopped tracing silently and returned an incomplete path with no indication anything had been truncated.
- The cap is now the `max_trace_hops` plugin setting (default 20), read at call time so runtime config and tests both take effect, and hitting it logs a warning.

## Changes

- `netbox_wdm/__init__.py`: `default_settings["max_trace_hops"] = 20`
- `netbox_wdm/trace.py`: `get_max_trace_hops()` and `warn_max_trace_hops_reached()` helpers; `_get_far_end_node` honours the budget and warns on exhaustion
- `netbox_wdm/views.py`: the `_trace_cable_segment` walk uses the same budget and helpers
- `netbox_wdm/testing/topologies.py`, `testing/__init__.py`: new `sf_mux_long_chain` builder that chains patch-panel pass-through units, so a topology can exceed any given cap
- `tests/test_trace_hop_cap.py`: two tests per engine -- a long chain resolves with the cap raised, and the default cap truncates and logs
- `README.md`, `docs/user/getting-started.md`, `docs/developer/path-tracing.md`, `CHANGELOG.md`: document the setting

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (191 passed)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (if schema changed) -- n/a, no schema change
- [x] Docs updated (README, docs site, CHANGELOG)

The warning surfaces on logger `netbox_wdm.trace` at WARNING level, naming the origin port and hop count and pointing at the setting.

Note on the literal `20` fallback in `get_max_trace_hops()`: it duplicates `default_settings` on purpose, so a `PLUGINS_CONFIG` override that omits the key cannot produce `range(None)`.

## Related

Closes #43
Refs #37
