### PR TITLE
ci: cap test job runtime at 90 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python }}, NetBox ${{ matrix.netbox }})
     runs-on: ubuntu-latest
+    # A hung infrastructure step (e.g. an apt mirror outage) otherwise burns
+    # the 6-hour GitHub default per matrix job. Slowest observed green run
+    # is about 1 hour; 90 minutes leaves headroom without masking hangs.
+    timeout-minutes: 90
     needs: lint
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds timeout-minutes: 90 to the test matrix job so a hung infrastructure step fails fast instead of burning the 6-hour GitHub Actions default.
- Motivated by the 2026-08-19 apt mirror outage: apt-get update hung in four test jobs across PRs #51 and #52, each running the full 6 hours with pytest never starting.

## Changes
- .github/workflows/ci.yml: timeout-minutes: 90 on the test job, with a comment explaining the choice (slowest observed green run is about 1 hour).

## Testing
- [x] ruff check passes (workflow-only change, not applicable)
- [x] ruff format --check passes (workflow-only change, not applicable)
- [x] pytest passes locally (workflow-only change, not applicable)
- [x] New/changed behavior covered by tests (not applicable; CI configuration)
- [x] Migration applied cleanly (no schema change)
- [x] Docs updated (not user-visible)

## Related
Refs: #51, #52