### PR TITLE
ci: add NetBox 4.7.0 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         netbox:
           # renovate: datasource=github-releases depName=netbox-community/netbox
           - "4.6.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.7.0"
     services:
       postgres:
         image: postgis/postgis:17-3.4
@@ -176,7 +178,7 @@ jobs:
           pytest tests/ -v --tb=short --cov=netbox_wdm --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.6.')
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.7.')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI now tests against the latest NetBox 4.6 release (4.6.10, previously
   4.6.8), with Renovate keeping the matrix pinned to the newest release
   of the supported minor.
+- CI additionally tests against NetBox 4.7.0, and the Codecov coverage
+  upload moved from the 4.6 lane to the 4.7 lane so coverage is measured
+  on the newest supported series. The migration dependencies pinned in
+  `0001_initial` (`dcim.0226_modulebay_rebuild_tree`,
+  `tenancy.0023_add_mptt_tree_indexes`) and the deep core imports the
+  plugin uses (`dcim.models.cables.trace_paths`, `netbox.signals.post_clean`,
+  `dcim.models.device_component_templates.PortTemplateMapping`) all still
+  resolve on 4.7.0. Full NetBox 4.7 support is not declared yet: it stays
+  gated on the cassette-overlay module-relocation gap tracked in
+  [#76](https://github.com/jsenecal/netbox-wdm/issues/76).
+  ([#77](https://github.com/jsenecal/netbox-wdm/issues/77))
 - **BREAKING:** the C-band grid keys are renamed to carry an explicit band segment, so both bands read alike now that L-band grids exist: `dwdm_100ghz` becomes `dwdm_c_100ghz` and `dwdm_50ghz` becomes `dwdm_c_50ghz`. Migration `0012_rename_c_band_grid_keys` rewrites the stored `grid` value on every `WdmProfile` and `WdmNode` row, and is reversible. Anything outside the database that names the old keys must be updated by hand: REST/GraphQL filter values, saved filters, export templates, scripts, and webhook payloads. Channel labels and wavelengths are unaffected -- only the key changes. The Python names follow suit: `WdmGridChoices.DWDM_100GHZ` becomes `WdmGridChoices.DWDM_C_100GHZ`, and `DWDM_100GHZ_CHANNELS` becomes `DWDM_C_100GHZ_CHANNELS`. ([#69](https://github.com/jsenecal/netbox-wdm/issues/69))
 - Cable-chain traversal is delegated to NetBox's own `CablePath.from_origin` walker instead of the plugin's two hand-unrolled walkers (one in `trace.py` for path discovery, one in `views.py` for trace rendering), which each understood a single cabling permutation. Both now read one ephemeral walk via `core_walk.walk_from_rear_port`; nothing is persisted to core's `CablePath` table. Strand pairing on multi-terminated cables continues to come from the cable profile. ([#49](https://github.com/jsenecal/netbox-wdm/issues/49))
 - The chain walker refuses any chain that revisits a port, logging a warning rather than tracing it: core's walker carries no visited set and would spin forever inside a signal handler. ([#49](https://github.com/jsenecal/netbox-wdm/issues/49))

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,12 @@
       "matchPackageNames": ["netbox-community/netbox"],
       "matchCurrentValue": "/^4\\.6\\./",
       "allowedVersions": "/^4\\.6\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.7\\./",
+      "allowedVersions": "/^4\\.7\\./"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Adds NetBox 4.7.0 to the CI test matrix (keeping 4.6.10) and moves the Codecov upload to the 4.7 lane; adds the Renovate per-minor lane for 4.7.
- Verified on a live NetBox 4.7.0 / Django 6.1 instance: the migration dependencies pinned in 0001_initial (dcim.0226_modulebay_rebuild_tree, tenancy.0023_add_mptt_tree_indexes) still resolve in the 4.7 migration graph, and the deep core imports (dcim.models.cables.trace_paths, netbox.signals.post_clean, dcim.models.device_component_templates.PortTemplateMapping) keep their usage contracts.
- Deliberately does NOT declare 4.7 support in README/docs: that stays gated on the cassette-overlay module-relocation gap (#76). The CHANGELOG entry records the gate.

## Changes
- .github/workflows/ci.yml: renovate-annotated 4.7.0 matrix entry; codecov condition anchored to startsWith '4.7.'
- renovate.json: allowedVersions lane for /^4\.7\./
- CHANGELOG.md: Unreleased entry recording the 4.7 lane, verifications, and the #76 gate

## Testing
- [x] Migration-graph and deep-import verification on live 4.7.0 (no code changes needed)
- [x] Workflow YAML and renovate.json parse cleanly
- [ ] `ruff check` / `ruff format --check` -- not applicable (no Python touched)
- [ ] Full suite on 4.7 -- left to this PR's CI run (new 4.7.0 lane)

## Related
Refs: #77
